### PR TITLE
Adding build matrix for windows and ubuntu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,13 +10,17 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
-jobs:
+jobs:   
   build:
     # The CMake configure and build commands are platform agnostic and should
     # work equally well on Windows or Mac. You can convert this to a matrix
     # build if you need cross-platform coverage. See
     # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    strategy:
+     matrix:
+      os: [ubuntu-latest, windows-latest]
+      
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
To summarize the compilation with msvc I would like to add the build matrix to run cmake+build on github for windows and ubuntu. This will create two jobs:
![image](https://user-images.githubusercontent.com/5434718/155553436-172bec6a-98dd-4a23-9e29-3b67d4b5a079.png)

If further changes to the project are made, this will ensure they are both compatible with gcc and with msvc.
Please consider it :)